### PR TITLE
feat: Modal 컴포넌트 추가

### DIFF
--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -30,9 +30,26 @@ const ModalContainer = styled.div`
   border-radius: 8px;
 `
 
-const Modal = ({ children, width, height, visible = false, onClose, ...props }) => {
-  const ref = useClickAway(() => {
-    onClose && onClose()
+const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  &::after {
+    content: 'X';
+  }
+`
+
+const Modal = ({
+  children,
+  width,
+  height,
+  visible = false,
+  onClose,
+  activeWrapper = true,
+  ...props
+}) => {
+  const onClickModalWrapper = useClickAway(() => {
+    activeWrapper && onClose && onClose()
   })
 
   const containerStyle = useMemo(
@@ -53,7 +70,12 @@ const Modal = ({ children, width, height, visible = false, onClose, ...props }) 
 
   return ReactDOM.createPortal(
     <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
-      <ModalContainer ref={ref} {...props} style={{ ...props.style, ...containerStyle }}>
+      <ModalContainer
+        ref={onClickModalWrapper}
+        {...props}
+        style={{ ...props.style, ...containerStyle }}
+      >
+        <ModalCloseButton onClick={onClose} />
         {children}
       </ModalContainer>
     </BackgroundDim>,
@@ -61,12 +83,17 @@ const Modal = ({ children, width, height, visible = false, onClose, ...props }) 
   )
 }
 
+Modal.defaultProps = {
+  activeWrapper: true,
+}
+
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   visible: PropTypes.bool,
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+  activeWrapper: PropTypes.bool,
 }
 
 export default Modal

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -22,20 +22,27 @@ const ModalContainer = styled.div`
   position: fixed;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
   padding: 8px;
+  transform: translate(-50%, -50%);
   background-color: white;
   box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
   box-sizing: border-box;
   border-radius: 8px;
 `
 
+// Todo
+// 1. 버튼 안에 'X'를 아이콘으로 변경
+// 2. 임시로 최소 스타일링만 해놓았습니다, color같은 부분은 추후 디자인할때 다시 수정하면 좋을 것 같아요.
 const ModalCloseButton = styled.button`
   position: absolute;
-  top: 10px;
-  right: 10px;
-  &::after {
-    content: 'X';
+  top: 8px;
+  right: 8px;
+  background-color: #fafafa;
+  border: 0.5px solid gray;
+  border-radius: 4px;
+  cursor: pointer;
+  &:hover {
+    background-color: gray;
   }
 `
 

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import ReactDOM from 'react-dom'
+import { useEffect, useMemo } from 'react'
+import useClickAway from '../../../hooks/useClickAway'
+
+const BackgroundDim = styled.div`
+  box-sizing: border-box;
+  background-color: rgba(0, 0, 0, 0.3);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px;
+  background-color: white;
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  box-sizing: border-box;
+  border-radius: 8px;
+`
+
+const Modal = ({ children, width, height, visible = false, onClose, ...props }) => {
+  const ref = useClickAway(() => {
+    onClose && onClose()
+  })
+
+  const containerStyle = useMemo(
+    () => ({
+      width,
+      height,
+    }),
+    [width, height]
+  )
+
+  const portalDivFragment = useMemo(() => document.createElement('div'), [])
+  useEffect(() => {
+    document.body.appendChild(portalDivFragment)
+    return () => {
+      document.body.removeChild(portalDivFragment)
+    }
+  })
+
+  return ReactDOM.createPortal(
+    <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
+      <ModalContainer ref={ref} {...props} style={{ ...props.style, ...containerStyle }}>
+        {children}
+      </ModalContainer>
+    </BackgroundDim>,
+    portalDivFragment
+  )
+}
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  visible: PropTypes.bool,
+  onClose: PropTypes.func,
+}
+
+export default Modal

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import ReactDOM from 'react-dom'
 import { useEffect, useMemo } from 'react'
-import useClickAway from '../../../hooks/useClickAway'
+import useClickAway from '@hooks/useClickAway'
 
 const BackgroundDim = styled.div`
   box-sizing: border-box;
@@ -45,11 +45,11 @@ const Modal = ({
   height,
   visible = false,
   onClose,
-  activeWrapper = true,
+  closeOnClickOutside = true,
   ...props
 }) => {
   const onClickModalWrapper = useClickAway(() => {
-    activeWrapper && onClose && onClose()
+    closeOnClickOutside && onClose && onClose()
   })
 
   const containerStyle = useMemo(
@@ -75,7 +75,7 @@ const Modal = ({
         {...props}
         style={{ ...props.style, ...containerStyle }}
       >
-        <ModalCloseButton onClick={onClose} />
+        <ModalCloseButton onClick={onClose}>X</ModalCloseButton>
         {children}
       </ModalContainer>
     </BackgroundDim>,
@@ -84,7 +84,7 @@ const Modal = ({
 }
 
 Modal.defaultProps = {
-  activeWrapper: true,
+  closeOnClickOutside: true,
 }
 
 Modal.propTypes = {
@@ -93,7 +93,7 @@ Modal.propTypes = {
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   visible: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  activeWrapper: PropTypes.bool,
+  closeOnClickOutside: PropTypes.bool,
 }
 
 export default Modal

--- a/src/hooks/useClickAway.js
+++ b/src/hooks/useClickAway.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+
+const events = ['mousedown', 'touchstart']
+
+const useClickAway = (handler) => {
+  const ref = useRef(null)
+  const savedHandler = useRef(handler)
+
+  useEffect(() => {
+    savedHandler.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const handleEvent = (e) => {
+      !element.contains(e.target) && savedHandler.current(e)
+    }
+
+    for (const eventName of events) {
+      document.addEventListener(eventName, handleEvent)
+    }
+
+    return () => {
+      for (const eventName of events) {
+        document.removeEventListener(eventName, handleEvent)
+      }
+    }
+  }, [ref])
+
+  return ref
+}
+
+export default useClickAway

--- a/src/stories/components/Modal.stories.js
+++ b/src/stories/components/Modal.stories.js
@@ -6,25 +6,30 @@ export default {
   component: Modal,
 }
 
-const SampleComponent = ({ onClose }) => {
+export const Default = () => {
+  const [showModal, setShowModal] = useState(false)
+
   return (
     <div>
-      <h1>모달이 쨘!</h1>
-      <button onClick={onClose}>X</button>
+      <Modal visible={showModal} onClose={() => setShowModal(false)}>
+        <h1>모달이 쨘!</h1>
+      </Modal>
+      <h1>여기는 메인 화면이에요</h1>
+      <button onClick={() => setShowModal(true)}>모달을 띄우는 버튼</button>
     </div>
   )
 }
 
-export const Default = () => {
-  const [visible, setVisible] = useState(false)
+export const NotActiveWrapper = () => {
+  const [showModal, setShowModal] = useState(false)
 
   return (
     <div>
-      <Modal visible={visible} onClose={() => setVisible(false)}>
-        <SampleComponent onClose={() => setVisible(false)} />
+      <Modal visible={showModal} onClose={() => setShowModal(false)} activeWrapper={false}>
+        <h1>이 모달은 바깥을 눌러도 닫히지 않아요</h1>
       </Modal>
       <h1>여기는 메인 화면이에요</h1>
-      <button onClick={() => setVisible(true)}>모달을 띄우는 버튼</button>
+      <button onClick={() => setShowModal(true)}>모달을 띄우는 버튼</button>
     </div>
   )
 }

--- a/src/stories/components/Modal.stories.js
+++ b/src/stories/components/Modal.stories.js
@@ -25,7 +25,7 @@ export const NotActiveWrapper = () => {
 
   return (
     <div>
-      <Modal visible={showModal} onClose={() => setShowModal(false)} activeWrapper={false}>
+      <Modal visible={showModal} onClose={() => setShowModal(false)} closeOnClickOutside={false}>
         <h1>이 모달은 바깥을 눌러도 닫히지 않아요</h1>
       </Modal>
       <h1>여기는 메인 화면이에요</h1>

--- a/src/stories/components/Modal.stories.js
+++ b/src/stories/components/Modal.stories.js
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import Modal from '../../components/base/Modal'
+
+export default {
+  title: 'Component/Modal',
+  component: Modal,
+}
+
+const SampleComponent = ({ onClose }) => {
+  return (
+    <div>
+      <h1>모달이 쨘!</h1>
+      <button onClick={onClose}>X</button>
+    </div>
+  )
+}
+
+export const Default = () => {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <div>
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <SampleComponent onClose={() => setVisible(false)} />
+      </Modal>
+      <h1>여기는 메인 화면이에요</h1>
+      <button onClick={() => setVisible(true)}>모달을 띄우는 버튼</button>
+    </div>
+  )
+}

--- a/src/stories/hooks/useClickAway.stories.js
+++ b/src/stories/hooks/useClickAway.stories.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+import { useState } from 'react'
+import useClickAway from '../../hooks/useClickAway'
+export default {
+  title: 'Hook/useClickAway',
+}
+
+const Popover = styled.div`
+  width: 200px;
+  height: 200px;
+  border: 2px solid black;
+  background-color: #eee;
+`
+
+export const Default = () => {
+  const [show, setShow] = useState(false)
+  const ref = useClickAway((e) => {
+    if (e.target.tagName !== 'BUTTON') {
+      setShow(false)
+    }
+  })
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>이 버튼을 누르면?</button>
+      <Popover ref={ref} style={{ display: show ? 'block' : 'none' }}>
+        쨘!
+      </Popover>
+    </div>
+  )
+}


### PR DESCRIPTION
### ✅ 이슈 번호

#1 feat: Modal 컴포넌트 구현

### 작업 내용(자세히)

<img width="800" alt="스크린샷 2022-06-10 오전 12 35 25" src="https://user-images.githubusercontent.com/64957267/172887194-bde798c2-a62f-4649-bdd0-a24781d0e9a0.png">


1\. Modal 컴포넌트를 구현하였습니다. 
  - Modal 컴포넌트는 기본적으로 사이즈를 갖지 않도록 했습니다.
  - Modal 컴포넌트의 상태는 Modal 컴포넌트를 사용하는 쪽에서 `useState`로 컨트롤 합니다.
  - `Modal.stories.js`에 샘플 코드를 넣어놓았으니 참고해주세요.

2\. `useClickAway` 훅이 추가되었습니다.
  - 컴포넌트를 구현하는 과정에서 `useClickAway` 훅이 추가로 구현되었습니다. `useClickAway` 훅은 `useRef`를 이용해서 특정 DOM에 이벤트를 바인딩하는 훅입니다.

3\. Modal 컴포넌트 안에 모달을 닫는 버튼을 추가했습니다.
  - 버튼의 위치만 스타일링했고 디자인은 하지 않았습니다.

4\. Modal 컴포넌트에 `activeWrapper` 라는 옵션을 추가했습니다.
  - 기본 값은 `true` 입니다.
  - 만약 모달 바깥을 클릭해도 모달이 닫히지 않게 하고 싶다면 `false`로 옵션을 넣으면 됩니다.
  - `Modal.stories.js`에 샘플 코드를 넣어놓았으니 참고해주세요.

#### 피드백반영

1\. 'activeWrapper' 네이밍을 'closeOnClickOutside`로 변경
2\. 모달을 닫는 버튼에 최소한의 css를 추가
  - 아직 디자인이 명확하지 않아 임의로 추가했습니다.


### 구현 날짜

6월 9일

### 어려웠던 점

`activeWrapper` 라는 네이밍이 조금 찜찜하네요. 직관적이지 않은 네이밍은 네이밍 추천해주시면 감사하겠습니다... 잘 떠오르지 않네요 ㅜㅜ