### PR TITLE
feat: select 컴포넌트 생성

### DIFF
--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled'
+import propTypes from 'prop-types'
 
 const Wrapper = styled.div`
-  display: ${({ block }) => (block ? 'block' : 'inline=block')};
+  display: ${({ block }) => (block ? 'block' : 'inline-block')};
 `
 
 const Label = styled.label`
-  display: block;
+  display: none;
   font-size: 16px;
   color: #743737;
   margin-bottom: 5px;
@@ -56,6 +57,25 @@ const Select = ({
       </StyledSelect>
     </Wrapper>
   )
+}
+
+Select.propTypes = {
+  data: propTypes.arrayOf(
+    propTypes.oneOfType([
+      propTypes.string,
+      propTypes.shape({
+        label: propTypes.string,
+        value: propTypes.string,
+      }),
+    ])
+  ),
+  label: propTypes.string,
+  placeholder: propTypes.string,
+  block: propTypes.bool,
+  invalid: propTypes.bool,
+  required: propTypes.bool,
+  disabled: propTypes.bool,
+  wrapperProps: propTypes.object,
 }
 
 export default Select

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import propTypes from 'prop-types'
+import PropTypes from 'prop-types'
 
 const Wrapper = styled.div`
   display: ${({ block }) => (block ? 'block' : 'inline-block')};
@@ -60,22 +60,22 @@ const Select = ({
 }
 
 Select.propTypes = {
-  data: propTypes.arrayOf(
-    propTypes.oneOfType([
-      propTypes.string,
-      propTypes.shape({
-        label: propTypes.string,
-        value: propTypes.string,
+  data: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        label: PropTypes.string,
+        value: PropTypes.string,
       }),
     ])
   ),
-  label: propTypes.string,
-  placeholder: propTypes.string,
-  block: propTypes.bool,
-  invalid: propTypes.bool,
-  required: propTypes.bool,
-  disabled: propTypes.bool,
-  wrapperProps: propTypes.object,
+  label: PropTypes.string,
+  placeholder: PropTypes.string,
+  block: PropTypes.bool,
+  invalid: PropTypes.bool,
+  required: PropTypes.bool,
+  disabled: PropTypes.bool,
+  wrapperProps: PropTypes.object,
 }
 
 export default Select

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled'
+
+const Wrapper = styled.div`
+  display: ${({ block }) => (block ? 'block' : 'inline=block')};
+`
+
+const Label = styled.label`
+  display: block;
+  font-size: 16px;
+  color: #743737;
+  margin-bottom: 5px;
+`
+
+const StyledSelect = styled.select`
+  width: 100%;
+  padding: 4px 6px;
+  border: 2px solid ${({ invalid }) => (invalid ? 'red' : '#743737')};
+  border-radius: 4px;
+  box-sizing: border-box;
+`
+
+const Select = ({
+  data,
+  label,
+  placeholder,
+  block = false,
+  invalid = false,
+  required = false,
+  disabled = false,
+  wrapperProps,
+  ...props
+}) => {
+  const formattedData = data.map((item) =>
+    typeof item === 'string' ? { label: item, value: item } : item
+  )
+
+  const options = formattedData.map((item) => (
+    <option key={item.value} value={item.value}>
+      {item.label}
+    </option>
+  ))
+
+  if (placeholder) {
+    options.unshift(
+      <option key="placeholder" value="" hidden>
+        {placeholder}
+      </option>
+    )
+  }
+
+  return (
+    <Wrapper block={block} {...wrapperProps}>
+      <Label>{label}</Label>
+      <StyledSelect invalid={invalid} required={required} disabled={disabled} {...props}>
+        {options}
+      </StyledSelect>
+    </Wrapper>
+  )
+}
+
+export default Select

--- a/src/stories/components/Select.stories.js
+++ b/src/stories/components/Select.stories.js
@@ -1,0 +1,44 @@
+import Select from '../../components/base/Select'
+
+export default {
+  title: 'Component/Select',
+  component: Select,
+  argTypes: {
+    label: {
+      defaultValue: '카테고리',
+      control: 'text',
+    },
+    placeholder: {
+      defaultValue: '원하시는 장르를 선택해주세요.',
+      control: 'text',
+    },
+    block: {
+      defaultValue: false,
+      control: 'boolean',
+    },
+    invalid: {
+      defaultValue: false,
+      control: 'boolean',
+    },
+    disabled: {
+      defaultValue: false,
+      control: 'boolean',
+    },
+    required: {
+      defaultValue: false,
+      control: 'boolean',
+    },
+  },
+}
+
+export const Default = (args) => (
+  <Select
+    data={[
+      { label: '소설', value: 'value' },
+      { label: '에세이', value: 'value' },
+      { label: '공포', value: 'value' },
+      { label: '기술', value: 'value' },
+    ]}
+    {...args}
+  />
+)


### PR DESCRIPTION
### ✅ 이슈 번호
#2 feat: Select 컴포넌트 생성
### 작업 내용(자세히)
기본
![image](https://user-images.githubusercontent.com/67237560/172890790-56ac80cb-925a-4775-89e2-803e6120f457.png)
클릭 시
![image](https://user-images.githubusercontent.com/67237560/172891314-29500263-513a-4c48-8204-0d748e8b7c1c.png)
선택 시
![image](https://user-images.githubusercontent.com/67237560/172891433-33ceeb69-19ef-4cd2-9fca-929d4f108d0e.png)

1. Select 컴포넌트 추가
 - Label은 카테고리
 - Placeholder는 유도 문구로 넣으면 될거라 생각됩니다.
 - 색상은 피그마에 있는 시그니처 색으로 border와 label 색상을 지정해놨습니다.
 - Select 안에 텍스트는 기본 검은색으로 하는게 좋을 것 같아 따로 지정하지 않았습니다.


### 구현 날짜
2022-06-10
