### PR TITLE
feat: icon 컴포넌트 생성

### DIFF
--- a/src/components/base/Icon/index.js
+++ b/src/components/base/Icon/index.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+import { Buffer } from 'buffer'
+
+const IconWrapper = styled.i`
+  display: inline-block;
+`
+
+const Icon = ({ name, size = 16, strokeWidth = 2, rotate, color = '#743737', ...props }) => {
+  const shapeStyle = {
+    width: size,
+    height: size,
+    transform: rotate ? `rotate(${rotate}deg)` : undefined,
+  }
+  const iconStyle = {
+    'stroke-width': strokeWidth,
+    stroke: color,
+    width: size,
+    height: size,
+  }
+  const icon = require('feather-icons').icons[name]
+  const svg = icon ? icon.toSvg(iconStyle) : ''
+  const base64 = Buffer.from(svg, 'utf8').toString('base64')
+
+  return (
+    <IconWrapper {...props} style={{ ...props.style, ...shapeStyle }}>
+      <img src={`data:image/svg+xml;base64,${base64}`} alt={name} />
+    </IconWrapper>
+  )
+}
+
+export default Icon

--- a/src/stories/components/Icon.stories.js
+++ b/src/stories/components/Icon.stories.js
@@ -1,0 +1,20 @@
+import Icon from '../../components/base/Icon'
+
+export default {
+  title: 'Component/Icon',
+  component: Icon,
+  argTypes: {
+    name: { defaultValue: 'box', control: 'text' },
+    size: { defaultValue: 16, control: { type: 'range', min: 16, max: 80 } },
+    strokeWidth: {
+      defaultValue: 2,
+      control: { type: 'range', min: 2, max: 6 },
+    },
+    rotate: { defaultValue: 0, control: { type: 'range', min: 0, max: 360 } },
+    color: { defaultValue: '#743737', control: 'color' },
+  },
+}
+
+export const Default = (args) => {
+  return <Icon {...args} />
+}


### PR DESCRIPTION
### ✅ 이슈 번호
#12 feat: Icon 컴포넌트 생성
### 작업 내용(자세히)
기본 예시) bell
![image](https://user-images.githubusercontent.com/67237560/172926561-74fb9c4d-e272-4dc8-b965-d8e0bd221d76.png)
storkewidth 변경
![image](https://user-images.githubusercontent.com/67237560/172926883-5512efe8-6ee6-4370-8545-c08a3ff4693f.png)
rotate로 각도 변경 예시) 90도
![image](https://user-images.githubusercontent.com/67237560/172927399-dea3f054-db78-4639-85e9-3f8ee0435e8e.png)

1. Icon 컴포넌트 추가
- size, strokeWidth, color, name, rotate 속성을 주었습니다.
- 기본 색상은 #743737 입니다.

2. 라이브러리/모듈 설치 필요
- 아이콘을 사용하기 위하여 feather-icons 라이브러리 설치가 필요합니다.
- 기존의 CRA에 Buffer 모듈이 없어 Buffer 모듈 설치가 필요합니다.
- 설치에 대한 내용은 안건에 올렸습니다.
### 구현 날짜
2022년 06월 10일
