### PR TITLE
feat: Image 컴포넌트 구현

### DIFF
--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -34,9 +34,6 @@ const Image = ({
     width,
     height,
     objectFit: mode,
-    filter: loaded ? 'none' : 'blur(10px)',
-    'clip-path': loaded ? 'none' : 'inset(0)',
-    transition: loaded ? 'filter 0.5s linear' : undefined,
   }
 
   useEffect(() => {

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -34,6 +34,9 @@ const Image = ({
     width,
     height,
     objectFit: mode,
+    filter: loaded ? 'none' : 'blur(10px)',
+    'clip-path': loaded ? 'none' : 'inset(0)',
+    transition: loaded ? 'filter 0.5s linear' : undefined,
   }
 
   useEffect(() => {

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types'
+import { useState, useRef, useEffect } from 'react'
+
+let observer = null
+const LOAD_IMG_EVENT_TYPE = 'loadImage'
+const PLAYCEHOLDER_SRC = 'https://via.placeholder.com/200?text=LUVOOK'
+
+const onIntersection = (entries, io) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      io.unobserve(entry.target)
+      entry.target.dispatchEvent(new CustomEvent(LOAD_IMG_EVENT_TYPE))
+    }
+  })
+}
+
+const Image = ({
+  lazy,
+  threshold = 0.3,
+  placeholder = PLAYCEHOLDER_SRC,
+  src,
+  block,
+  width,
+  height,
+  alt,
+  mode,
+  ...props
+}) => {
+  const [loaded, setLoaded] = useState(false)
+  const imgRef = useRef(null)
+
+  const imageStyle = {
+    display: block ? 'block' : undefined,
+    width,
+    height,
+    objectFit: mode,
+  }
+
+  useEffect(() => {
+    if (!lazy) {
+      setLoaded(true)
+      return
+    }
+
+    const handleLoadImage = () => setLoaded(true)
+
+    const imgElement = imgRef.current
+    imgElement && imgElement.addEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage)
+
+    return () => {
+      imgElement && imgElement.addEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage)
+    }
+  }, [lazy])
+
+  useEffect(() => {
+    if (!lazy) return
+    observer = new IntersectionObserver(onIntersection, { threshold })
+    imgRef.current && observer.observe(imgRef.current)
+  }, [lazy, threshold])
+
+  return (
+    <img
+      ref={imgRef}
+      src={loaded ? src : placeholder}
+      style={{ ...props.style, ...imageStyle }}
+      alt={alt}
+    />
+  )
+}
+
+Image.propTypes = {
+  lazy: PropTypes.bool,
+  threshold: PropTypes.number,
+  placeholder: PropTypes.string,
+  src: PropTypes.string.isRequired,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  alt: PropTypes.string,
+  mode: PropTypes.string,
+}
+export default Image

--- a/src/stories/components/Image.stories.js
+++ b/src/stories/components/Image.stories.js
@@ -1,0 +1,64 @@
+import Image from '../../components/Image'
+
+export default {
+  title: 'Component/Image',
+  component: Image,
+  argTypes: {
+    lazy: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    block: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    src: {
+      name: 'src',
+      type: { name: 'string', required: true },
+      defaultValue: 'https://source.unsplash.com/random',
+      control: { type: 'text' },
+    },
+    placeholder: {
+      type: { name: 'string' },
+      control: { type: 'text' },
+    },
+    threshold: {
+      type: { name: 'number' },
+      defaultValue: 0.5,
+      control: { type: 'number' },
+    },
+    width: {
+      name: 'width',
+      defaultValue: 200,
+      control: { type: 'range', min: 200, max: 600 },
+    },
+    height: {
+      name: 'height',
+      defaultValue: 200,
+      control: { type: 'range', min: 200, max: 600 },
+    },
+    alt: {
+      name: 'alt',
+      control: 'string',
+    },
+    mode: {
+      defaultValue: 'cover',
+      options: ['cover', 'fill', 'contain'],
+      control: { type: 'inline-radio' },
+    },
+  },
+}
+
+export const Default = (args) => {
+  return <Image {...args} />
+}
+
+export const Lazy = (args) => {
+  return (
+    <div>
+      {Array.from(new Array(20), (_, k) => k).map((i) => (
+        <Image {...args} lazy block src={`${args.src}?${i}`} key={i} />
+      ))}
+    </div>
+  )
+}

--- a/src/stories/components/Image.stories.js
+++ b/src/stories/components/Image.stories.js
@@ -56,6 +56,9 @@ export const Default = (args) => {
 export const Lazy = (args) => {
   return (
     <div>
+      <h1>Lazy Loding 예시</h1>
+      <h2>이미지 크기를 키우면 확인이 쉽습니다</h2>
+
       {Array.from(new Array(20), (_, k) => k).map((i) => (
         <Image {...args} lazy block src={`${args.src}?${i}`} key={i} />
       ))}


### PR DESCRIPTION
### ✅ 이슈 번호
#8 
### 작업 내용(자세히)
이미지 컴포넌트를 구현하였습니다.
- 컴포넌트의 속성을 통하여, 이미지 속성을 제어할 수 있습니다.
![컨트롤](https://user-images.githubusercontent.com/74234333/173019373-6c03a757-4929-420b-9a66-1ffe2014232e.PNG)

제어할 수 있는 속성은 위와 같습니다.

![lazyloading](https://user-images.githubusercontent.com/74234333/173019673-29df329e-da76-4000-92f4-a0078f1f44d8.gif)
- 이미지가 업로드 되기 전 placeholder 이미지와 이 후 이미지의 자연스러운 전환을 위하여 간단하게 css 전환효과를 넣었습니다. (근데 괜찮은지 모르겠습니다)

### 구현 날짜

2022년 6월 10일

### 어려웠던 점
