### PR TITLE
feat: Text 컴포넌트 구현

### DIFF
--- a/src/components/base/Text/index.js
+++ b/src/components/base/Text/index.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types'
+
+const fontSizeMap = {
+  small: 12,
+  normal: 16,
+  large: 20,
+}
+
+const calculateFontSize = (size) => {
+  if (fontSizeMap[size]) return fontSizeMap[size]
+
+  if (typeof size === 'number') return size
+
+  return fontSizeMap['normal']
+}
+
+const Text = ({ children, size, color, block, paragraph, strong, ...props }) => {
+  const Tag = block ? 'div' : paragraph ? 'p' : 'span'
+
+  const fontStyle = {
+    fontWeight: strong ? 'bold' : undefined,
+    fontSize: calculateFontSize(size),
+    color,
+  }
+
+  return (
+    <Tag style={{ ...props.style, ...fontStyle }} {...props}>
+      {children}
+    </Tag>
+  )
+}
+
+Text.propTypes = {
+  children: PropTypes.node.isRequired,
+  color: PropTypes.string,
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['small', 'normal', 'large'])]),
+  block: PropTypes.bool,
+  paragraph: PropTypes.bool,
+  strong: PropTypes.bool,
+}
+
+export default Text

--- a/src/components/base/Text/index.js
+++ b/src/components/base/Text/index.js
@@ -6,7 +6,7 @@ const fontSizeMap = {
   large: 20,
 }
 
-const calculateFontSize = (size) => {
+const formattedSize = (size) => {
   if (fontSizeMap[size]) return fontSizeMap[size]
 
   if (typeof size === 'number') return size
@@ -19,7 +19,7 @@ const Text = ({ children, size, color, block, paragraph, strong, ...props }) => 
 
   const fontStyle = {
     fontWeight: strong ? 'bold' : undefined,
-    fontSize: calculateFontSize(size),
+    fontSize: formattedSize(size),
     color,
   }
 

--- a/src/stories/components/Text.stories.js
+++ b/src/stories/components/Text.stories.js
@@ -1,0 +1,39 @@
+import Text from '@components/base/Text'
+
+export default {
+  title: 'Component/Text',
+  component: Text,
+  argTypes: {
+    size: { control: 'number' },
+    strong: { control: 'boolean' },
+    color: { control: 'color' },
+    block: { control: 'boolean' },
+    paragraph: { control: 'boolean' },
+  },
+}
+
+export const Default = (args) => {
+  return <Text {...args}>Text</Text>
+}
+
+export const Size = (args) => {
+  return (
+    <>
+      <Text {...args} block>
+        이건 기본 사이즈에요 (16px)
+      </Text>
+      <Text {...args} block size="large">
+        Large (20px)
+      </Text>
+      <Text {...args} block size="normal">
+        Normal (16px)
+      </Text>
+      <Text {...args} paragraph size="small">
+        Small (12px)
+      </Text>
+      <Text {...args} size={28} color="tomato">
+        이 글자는 28px 이고 색깔은 토마토색!
+      </Text>
+    </>
+  )
+}


### PR DESCRIPTION
### ✅ 이슈 번호

#11 

### 작업 내용(자세히)

`Text` 컴포넌트를 구현했습니다.

<img width="800" alt="스크린샷 2022-06-10 오후 5 29 55" src="https://user-images.githubusercontent.com/64957267/173024933-f1aedaef-7392-4f6c-bd95-0ec8072437fd.png">

size는 숫자나 문자열 `'small', 'normal', 'large'` 을 값으로 가질 수 있습니다. 스토리북을 참고해주세요!

### 구현 날짜

2022년 6월 10일
