### PR TITLE
feat: Divider 컴포넌트 생성

### DIFF
--- a/src/components/base/Divider/index.js
+++ b/src/components/base/Divider/index.js
@@ -16,22 +16,24 @@ const Line = styled.hr`
 
   &.horizontal {
     display: block;
-    width: 100%;
     height: 1px;
   }
 `
 
-const Divider = ({ type = 'horizontal', size = 8, ...props }) => {
+const Divider = ({ type = 'horizontal', width = '100%', size = 8, ...props }) => {
   const dividerStyle = {
     margin: type === 'vertical' ? `0 ${size}px` : `${size}px 0`,
   }
 
-  return <Line {...props} className={type} style={{ ...dividerStyle, ...props.style }} />
+  return (
+    <Line {...props} width={width} className={type} style={{ ...dividerStyle, ...props.style }} />
+  )
 }
 
 Divider.propTypes = {
   type: PropTypes.oneOf(['horizontal', 'vertical']),
   size: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default Divider

--- a/src/components/base/Divider/index.js
+++ b/src/components/base/Divider/index.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 
 const Line = styled.hr`
   border: none;
-  background-color: #aaa;
+  background-color: #743737;
 
   &.vertical {
     position: relative;

--- a/src/components/base/Divider/index.js
+++ b/src/components/base/Divider/index.js
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import PropTypes from 'prop-types'
 
 const Line = styled.hr`
   border: none;
@@ -26,6 +27,11 @@ const Divider = ({ type = 'horizontal', size = 8, ...props }) => {
   }
 
   return <Line {...props} className={type} style={{ ...dividerStyle, ...props.style }} />
+}
+
+Divider.propTypes = {
+  type: PropTypes.oneOf(['horizontal', 'vertical']),
+  size: PropTypes.number,
 }
 
 export default Divider

--- a/src/components/base/Divider/index.js
+++ b/src/components/base/Divider/index.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+
+const Line = styled.hr`
+  border: none;
+  background-color: #aaa;
+
+  &.vertical {
+    position: relative;
+    top: -1px;
+    display: inline-block;
+    width: 1px;
+    height: 13px;
+    vertical-align: middle;
+  }
+
+  &.horizontal {
+    display: block;
+    width: 100%;
+    height: 1px;
+  }
+`
+
+const Divider = ({ type = 'horizontal', size = 8, ...props }) => {
+  const dividerStyle = {
+    margin: type === 'vertical' ? `0 ${size}px` : `${size}px 0`,
+  }
+
+  return <Line {...props} className={type} style={{ ...dividerStyle, ...props.style }} />
+}
+
+export default Divider

--- a/src/stories/components/Divider.stories.js
+++ b/src/stories/components/Divider.stories.js
@@ -1,0 +1,26 @@
+import Divider from '@components/base/Divider'
+
+export default {
+  title: 'Component/Divder',
+  component: Divider,
+}
+
+export const Horizontal = () => {
+  return (
+    <>
+      <span>위</span>
+      <Divider type="horizontal" />
+      <span>아래</span>
+    </>
+  )
+}
+
+export const Vertical = () => {
+  return (
+    <>
+      <span>왼쪽</span>
+      <Divider type="vertical" />
+      <span>오른쪽</span>
+    </>
+  )
+}

--- a/src/stories/components/Divider.stories.js
+++ b/src/stories/components/Divider.stories.js
@@ -1,4 +1,4 @@
-import Divider from '@components/base/Divider'
+import Divider from '../../components/base/Divider'
 
 export default {
   title: 'Component/Divder',

--- a/src/stories/components/Divider.stories.js
+++ b/src/stories/components/Divider.stories.js
@@ -1,4 +1,4 @@
-import Divider from '../../components/base/Divider'
+import Divider from '@components/base/Divider'
 
 export default {
   title: 'Component/Divder',


### PR DESCRIPTION
### ✅ 이슈 번호
#14 feat: Divider 컴포넌트 생성
### 작업 내용(자세히)
horizontal (위아래)
![image](https://user-images.githubusercontent.com/67237560/173025429-df674939-2de1-4d81-b614-b8dced886d2d.png)
vertical (좌우)
![image](https://user-images.githubusercontent.com/67237560/173025516-bd52d139-4ea2-4590-9f30-81eac7a9b47e.png)

1. Divider 컴포넌트 생성
- 줄 색상은 #aaa에서 #743737로 변경했습니다.
- 스토리북에서 text로 테스트하려고 했으나 아직 컴포넌트가 없는 관계로 span으로 테스트 했습니다.
- horizontal 길이는 구간을 나눌때 사용할 듯 싶어 width값을 100%로 지정했습니다.
### 구현 날짜
2022년 06월 10일