### PR TITLE
feat: Title 컴포넌트 추가

### DIFF
--- a/src/components/base/Title/index.js
+++ b/src/components/base/Title/index.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types'
+
+const Title = ({ children, level = 1, strong, color, ...props }) => {
+  let Tag = `h${level}`
+  if (level < 1 || level > 6) {
+    console.warn("Title only accept '1 | 2 | 3 | 4 | 5 | 6' as level value.")
+    Tag = 'h1'
+  }
+
+  const fontStyle = {
+    fontWeight: strong ? 'bold' : 'normal',
+    color,
+  }
+
+  return (
+    <Tag style={{ ...props.style, ...fontStyle }} {...props}>
+      {children}
+    </Tag>
+  )
+}
+
+Title.propTypes = {
+  children: PropTypes.node.isRequired,
+  level: PropTypes.number,
+  strong: PropTypes.bool,
+  color: PropTypes.string,
+}
+
+export default Title

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
 export { default as Modal } from './base/Modal'
 export { default as Select } from './base/Select'
+export { default as Title } from './base/Title'

--- a/src/stories/components/Title.stories.js
+++ b/src/stories/components/Title.stories.js
@@ -1,0 +1,15 @@
+import { Title } from '@components'
+
+export default {
+  title: 'Component/Title',
+  component: Title,
+  argTypes: {
+    level: { control: { type: 'range', min: 1, max: 6 } },
+    strong: { control: 'boolean' },
+    color: { control: 'color' },
+  },
+}
+
+export const Default = (args) => {
+  return <Title {...args}>Title</Title>
+}


### PR DESCRIPTION
### ✅ 이슈 번호

#19

### 작업 내용(자세히)

Title 컴포넌트를 구현했습니다.

<img width="800" alt="스크린샷 2022-06-10 오후 6 35 53" src="https://user-images.githubusercontent.com/64957267/173037167-d18b3c6b-c843-4308-9c84-cb9c269f6bda.png">

1. Title 컴포넌트는 level 1 ~ 6까지 값을 받을 수 있습니다. default는 1이고 그 외의 값이 들어온다면 1로 반영합니다.
2. strong, color를 지정할 수 있습니다.

### 구현 날짜

2022년 6월 10일