### PR TITLE
feat: userContext 구현

### DIFF
--- a/src/contexts/UserContext/constants.js
+++ b/src/contexts/UserContext/constants.js
@@ -1,0 +1,3 @@
+export const SET_USER = 'SET_USER'
+export const RESET_USER = 'RESET_USER'
+export const SET_LOADING = 'SET_LOADING'

--- a/src/contexts/UserContext/constants.js
+++ b/src/contexts/UserContext/constants.js
@@ -1,3 +1,4 @@
 export const SET_USER = 'SET_USER'
 export const RESET_USER = 'RESET_USER'
 export const SET_LOADING = 'SET_LOADING'
+export const SET_LOADING_DONE = 'SET_LOADING_DONE'

--- a/src/contexts/UserContext/index.js
+++ b/src/contexts/UserContext/index.js
@@ -1,16 +1,14 @@
 import React, { createContext, useContext, useState, useReducer, useCallback } from 'react'
 import { reducer, initialUserData } from './reducer'
-import { SET_USER, RESET_USER, SET_LOADING } from './constants'
+import { SET_USER, RESET_USER, SET_LOADING, SET_LOADING_DONE } from './constants'
 // 동작 테스트를 위한 더미데이터, api 구현 후 대체할 부분
 import { handleLogin, handleLogout, handleAuth } from './test'
 
 export const useUserContext = () => {
   const context = useContext(UserContext)
-
   if (context === undefined) {
     throw new Error('useUserContext was used outside of its Provider')
   }
-
   return context
 }
 
@@ -23,11 +21,12 @@ export const UserContextProvider = ({ children }) => {
   const onAuth = useCallback(
     // TODO: api 통신을 통해 사용자가 인증이 되었는지 확인합니다.
     async (token) => {
+      dispatch({ type: SET_LOADING })
       const userData = await handleAuth(token)
-
       if (userData.user) {
         setIsAuth(true)
       }
+      dispatch({ type: SET_LOADING_DONE })
     },
     [handleAuth]
   )
@@ -38,9 +37,9 @@ export const UserContextProvider = ({ children }) => {
       dispatch({ type: SET_LOADING })
       const userData = await handleLogin(loginInfo)
       const { user, token } = userData
+      // 인증 후 로그인
+      await onAuth(token)
       dispatch({ type: SET_USER, payload: user })
-      // 로그인 후 인증
-      onAuth(token)
     },
     [handleLogin]
   )

--- a/src/contexts/UserContext/index.js
+++ b/src/contexts/UserContext/index.js
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useState, useReducer, useCallback } from 'react'
+import { reducer, initialUserData } from './reducer'
+import { SET_USER, RESET_USER, SET_LOADING } from './constants'
+// 동작 테스트를 위한 더미데이터, api 구현 후 대체할 부분
+import { handleLogin, handleLogout, handleAuth } from './test'
+
+export const useUserContext = () => {
+  const context = useContext(UserContext)
+
+  if (context === undefined) {
+    throw new Error('useUserContext was used outside of its Provider')
+  }
+
+  return context
+}
+
+const UserContext = createContext()
+
+export const UserContextProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialUserData)
+  const [isAuth, setIsAuth] = useState(false) // 현재 사용자의 auth 정보
+
+  const onAuth = useCallback(
+    // TODO: api 통신을 통해 사용자가 인증이 되었는지 확인합니다.
+    async (token) => {
+      const userData = await handleAuth(token)
+
+      if (userData.user) {
+        setIsAuth(true)
+      }
+    },
+    [handleAuth]
+  )
+
+  const onLogin = useCallback(
+    async (loginInfo) => {
+      // TODO: api 통신을 통해, 로그인 하고 {user, token} 객체를 받아옵니다.
+      dispatch({ type: SET_LOADING })
+      const userData = await handleLogin(loginInfo)
+      const { user, token } = userData
+      dispatch({ type: SET_USER, payload: user })
+      // 로그인 후 인증
+      onAuth(token)
+    },
+    [handleLogin]
+  )
+
+  const onLogout = useCallback(async () => {
+    // TODO: api 통신을 통해, 로그아웃 합니다.
+    dispatch({ type: SET_LOADING })
+    await handleLogout()
+    dispatch({ type: RESET_USER })
+    setIsAuth(false)
+  }, [handleLogout])
+
+  return (
+    <UserContext.Provider value={{ state, isAuth, onAuth, onLogin, onLogout }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export default UserContextProvider

--- a/src/contexts/UserContext/index.js
+++ b/src/contexts/UserContext/index.js
@@ -17,7 +17,7 @@ export const useUserContext = () => {
 const UserContext = createContext()
 
 export const UserContextProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(reducer, initialUserData)
+  const [currentUserState, dispatch] = useReducer(reducer, initialUserData)
   const [isAuth, setIsAuth] = useState(false) // 현재 사용자의 auth 정보
 
   const onAuth = useCallback(
@@ -54,7 +54,7 @@ export const UserContextProvider = ({ children }) => {
   }, [handleLogout])
 
   return (
-    <UserContext.Provider value={{ state, isAuth, onAuth, onLogin, onLogout }}>
+    <UserContext.Provider value={{ currentUserState, isAuth, onAuth, onLogin, onLogout }}>
       {children}
     </UserContext.Provider>
   )

--- a/src/contexts/UserContext/reducer.js
+++ b/src/contexts/UserContext/reducer.js
@@ -1,0 +1,41 @@
+import { createContext } from 'react'
+import { SET_USER, RESET_USER, SET_LOADING } from './constants'
+
+export const initialUserData = {
+  currentUser: {
+    image: null, // 프로필 이미지
+    role: null, // 문구로 사용되는 부분
+    posts: [],
+    likes: [],
+    comments: null,
+    notifications: null,
+    _id: null,
+    fullName: null,
+    email: null,
+    createdAt: null,
+    updatedAt: null,
+  },
+  isLoading: false,
+}
+
+export const UserContext = createContext(initialUserData)
+
+export const reducer = (state, { type, payload }) => {
+  switch (type) {
+    case SET_USER:
+      return {
+        ...state,
+        currentUser: payload.currentUser,
+        isLoading: false,
+      }
+    case RESET_USER:
+      return initialUserData
+    case SET_LOADING:
+      return {
+        ...state,
+        isLoading: true,
+      }
+    default:
+      throw new Error(`Unknown action type: ${type}`)
+  }
+}

--- a/src/contexts/UserContext/reducer.js
+++ b/src/contexts/UserContext/reducer.js
@@ -1,5 +1,5 @@
 import { createContext } from 'react'
-import { SET_USER, RESET_USER, SET_LOADING } from './constants'
+import { SET_USER, RESET_USER, SET_LOADING, SET_LOADING_DONE } from './constants'
 
 export const initialUserData = {
   currentUser: {
@@ -34,6 +34,11 @@ export const reducer = (state, { type, payload }) => {
       return {
         ...state,
         isLoading: true,
+      }
+    case SET_LOADING_DONE:
+      return {
+        ...state,
+        isLoading: false,
       }
     default:
       throw new Error(`Unknown action type: ${type}`)

--- a/src/contexts/UserContext/test.js
+++ b/src/contexts/UserContext/test.js
@@ -1,0 +1,48 @@
+// 동작을 테스트할 수 있는 함수와 더미데이터 입니다.
+
+export const DUMMY_USER = {
+  currentUser: {
+    image: 'https://via.placeholder.com/200?text=LUVOOK', // 프로필 이미지
+    role: { quote: '다람쥐 헌 쳇바퀴에 타고파' }, // 문구로 사용되는 부분
+    posts: [],
+    likes: [],
+    comments: [],
+    notifications: [],
+    _id: 1234,
+    fullName: '가나다랍',
+    email: '123@aaa.com',
+    createdAt: '2020-01-01',
+    updatedAt: '2020-01-01',
+  },
+  isLoading: false,
+}
+
+export const handleLogin = ({ email, password }) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        user: DUMMY_USER,
+        token: '1234',
+      })
+    }, 1000)
+  })
+}
+
+export const handleLogout = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve('로그아웃 완료')
+    }, 1000)
+  })
+}
+
+export const handleAuth = (token) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        user: DUMMY_USER,
+        token: '1234',
+      })
+    }, 1000)
+  })
+}

--- a/src/stories/contexts/UserContext.stories.js
+++ b/src/stories/contexts/UserContext.stories.js
@@ -1,0 +1,47 @@
+import { Title, Button, Avatar, Text } from '@components'
+import { useUserContext, UserContextProvider } from '@contexts/UserContext'
+
+export default {
+  title: 'Contexts/UserContext',
+}
+
+const loginInfo = {
+  email: '',
+  password: '',
+}
+
+const App = () => {
+  return (
+    <UserContextProvider>
+      <Title level={1}>UserContext 사용 예시</Title>
+      <Pages />
+    </UserContextProvider>
+  )
+}
+
+const Pages = () => {
+  const { state, isAuth, onAuth, onLogin, onLogout } = useUserContext()
+
+  return (
+    <div>
+      <Button onClick={() => onLogin(loginInfo)}>로그인 버튼</Button>
+      <Button onClick={() => onLogout()}>로그아웃 버튼</Button>
+
+      {isAuth && (
+        <div>
+          <Title level={2}>로그인 인증 완료</Title>
+          <div>
+            <Avatar src={state.currentUser.image} />
+            <Title level={2}>{state.currentUser.fullName}</Title>
+            <Title level={3}>{state.currentUser.fullName}의 문구</Title>
+            <Text size="normal">{state.currentUser.role.quote}</Text>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const Default = () => {
+  return <App />
+}

--- a/src/stories/contexts/UserContext.stories.js
+++ b/src/stories/contexts/UserContext.stories.js
@@ -27,6 +27,8 @@ const Pages = () => {
       <Button onClick={() => onLogin(loginInfo)}>로그인 버튼</Button>
       <Button onClick={() => onLogout()}>로그아웃 버튼</Button>
 
+      {currentUserState.isLoading && <Text>로딩중...</Text>}
+
       {isAuth && (
         <div>
           <Title level={2}>로그인 인증 완료</Title>

--- a/src/stories/contexts/UserContext.stories.js
+++ b/src/stories/contexts/UserContext.stories.js
@@ -20,7 +20,7 @@ const App = () => {
 }
 
 const Pages = () => {
-  const { state, isAuth, onAuth, onLogin, onLogout } = useUserContext()
+  const { currentUserState, isAuth, onAuth, onLogin, onLogout } = useUserContext()
 
   return (
     <div>
@@ -31,10 +31,10 @@ const Pages = () => {
         <div>
           <Title level={2}>로그인 인증 완료</Title>
           <div>
-            <Avatar src={state.currentUser.image} />
-            <Title level={2}>{state.currentUser.fullName}</Title>
-            <Title level={3}>{state.currentUser.fullName}의 문구</Title>
-            <Text size="normal">{state.currentUser.role.quote}</Text>
+            <Avatar src={currentUserState.currentUser.image} />
+            <Title level={2}>{currentUserState.currentUser.fullName}</Title>
+            <Title level={3}>{currentUserState.currentUser.fullName}의 문구</Title>
+            <Text size="normal">{currentUserState.currentUser.role.quote}</Text>
           </div>
         </div>
       )}


### PR DESCRIPTION
### ✅ 이슈 번호

#28 

### 작업 내용(자세히)
- 현 프로젝트에서 사용될 **전역 상태**는 현재 유저의 상태라고 판단하여(자세한 내용은 #28 참고), 현재 유저의 상태에 관한 userContext를 구현하였습니다. 
- 이 PR은 5가지의 파일로 이루어져 있으며, 아래는 각 파일에 대한 설명입니다.
1. `contexts/UserContext/index.js`
 다른 컴포넌트에서 UserContext를 사용하기 위한 custom hook인 `useUserContext`과, `UserContextProvider`로 구현되어 있습니다. `UserContextProvider` 에서는 `state` (유저와, 유저의 상태 로직에 관한 부분) 와 `isAuth` (인증 여부)로 나뉘어져 있으며, 이 context를 사용하는 쪽으로 상태 관련 로직을 리턴하게 됩니다.

2. `contexts/UserContext/reducer.js`
 `UserContextProvider`에서의 **전역 상태만을 관리하는 로직** 부분입니다. 

3. `contexts/UserContext/constant.js`
  `UserContextProvider`와 `reducer` 에서 사용한 action type을 상수로 모아놓은 부분입니다.
후에 constants 를 구현할 시 삭제할 부분 입니다.

4. `contexts/UserContext/test.js`
 전역 상태와 전역 상태 관련 로직을 테스트하는 코드와 더미데이터가 구현되어 있는 부분입니다.
 함수들의 경우, 후에 api 를 붙이기 위해서(async/await 로직을 붙이기 위해) promise를 리턴하도록 구현하였습니다. 그래서 테스트하면 딜레이가 조금 있습니다..(아래 스크린샷 참고) 3.과 같이 api 호출 로직 구현 후 삭제될 부분입니다.

**사용 예시 (스토리북에서 확인)**
![context_basic](https://user-images.githubusercontent.com/74234333/173257561-e91910ac-7488-4222-90a5-496492ee86b8.gif)

### 구현 날짜

2022년 6월 13일

### 어려웠던 점

- 로그아웃 로직의 경우 **낙관적 업데이트**(전역 상태를 먼저 정리 후, 로그아웃 api 호출)를 적용해 볼 수 있을 것 같습니다. 
 적용한 예시는 다음과 같습니다.
![context_optimistic](https://user-images.githubusercontent.com/74234333/173257538-2e5c3646-db98-4fb7-b27d-fc786adaabd5.gif)

- 프로젝트 회의 때,api로 받아오는 데이터 중 사용할 column만 사용하자는 이야기가 나왔는데, 이를 처리하는 로직을 구현해야 할 것 같습니다. 우선은, 사용하기로 한 column 에 대한 데이터를 가정하고 구현하였습니다.

부족한 부분이 많은 코드이고,  설명을 작성하면서도 어떻게 설명해야하나 어려운 점이 많았습니다ㅠㅠ
이해가 안되는 부분이 있으면 언제든지 말씀해주세요.