### PR TITLE
feat: 로그인/회원가입 formik 적용(+input 컴포넌트 리팩토링)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "buffer": "^6.0.3",
     "craco": "^0.0.3",
     "feather-icons": "^4.29.0",
+    "formik": "^2.2.9",
     "node-sass": "^7.0.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/apis/services/user.js
+++ b/src/apis/services/user.js
@@ -1,5 +1,4 @@
-const getCleanUserInfo = (rawUserInfo) => {
-  const { role, email, fullName, notifications, likes, posts, createdAt } = rawUserInfo.user
+const getCleanUserInfo = ({ role, email, fullName, notifications, likes, posts, createdAt }) => {
   return {
     quote: role,
     email,

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -22,8 +22,12 @@ const StyledInput = styled.input`
 `
 
 const Input = ({
+  type,
+  name,
   label,
+  value,
   placeholder,
+  onChange,
   block = false,
   invalid = false,
   required = false,
@@ -36,7 +40,11 @@ const Input = ({
     <Wrapper block={block} {...wrapperProps}>
       <Label>{label}</Label>
       <StyledInput
+        type={type}
+        name={name}
+        value={value}
         placeholder={placeholder}
+        onChange={onChange}
         invalid={invalid}
         required={required}
         disabled={disabled}
@@ -48,8 +56,12 @@ const Input = ({
 }
 
 Input.propTypes = {
+  type: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   label: PropTypes.string,
   placeholder: PropTypes.string,
+  onChange: PropTypes.func,
   block: PropTypes.bool,
   invalid: PropTypes.bool,
   required: PropTypes.bool,

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 const PRIMARY_COLOR = '#743737'
 
-const Wrapper = styled.div`
+const InputWrapper = styled.div`
   display: ${({ block }) => (block ? 'block' : 'inline-block')};
 `
 
@@ -37,7 +37,7 @@ const Input = ({
   ...props
 }) => {
   return (
-    <Wrapper block={block} {...wrapperProps}>
+    <InputWrapper block={block} {...wrapperProps}>
       <Label>{label}</Label>
       <StyledInput
         type={type}
@@ -51,7 +51,7 @@ const Input = ({
         readOnly={readonly}
         {...props}
       />
-    </Wrapper>
+    </InputWrapper>
   )
 }
 

--- a/src/components/domain/Form/ErrorText/index.js
+++ b/src/components/domain/Form/ErrorText/index.js
@@ -1,0 +1,11 @@
+import { Text } from '@components'
+
+const ErrorText = ({ children }) => {
+  return (
+    <Text size="small" color="red">
+      {children}
+    </Text>
+  )
+}
+
+export default ErrorText

--- a/src/components/domain/Form/Login/index.js
+++ b/src/components/domain/Form/Login/index.js
@@ -1,30 +1,40 @@
 import SubmitButton from '../SubmitButton'
 import Form from '../index'
 import { Input } from '@components'
-import { useForm } from '@hooks'
 import { login, getCleanUserInfo } from '@apis'
+import { useFormik } from 'formik'
 
 const Login = () => {
-  const { handleChange, handleSubmit } = useForm({
-    initialValue: {
+  const { values, handleSubmit, handleChange } = useFormik({
+    initialValues: {
       email: '',
       password: '',
     },
     onSubmit: async (userInfo) => {
-      await login(userInfo)
-        .then(getCleanUserInfo)
-        .then((res) => console.log(res))
+      const { user, token } = await login(userInfo)
+      const cleanUserInfo = getCleanUserInfo(user)
+      // TODO
+      // cleanUserInfo userContext 유저에 적용하기
+      // token, localStorage에 적용
+      // 로그인 성공 시 main 이동
     },
   })
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Input type="text" name="email" placeholder="이메일을 입력해주세요" onChange={handleChange} />
+      <Input
+        type="text"
+        name="email"
+        placeholder="이메일을 입력해주세요"
+        onChange={handleChange}
+        value={values.email}
+      />
       <Input
         type="password"
         name="password"
         placeholder="비밀번호를 입력해주세요"
         onChange={handleChange}
+        value={values.password}
       />
       <SubmitButton>로그인</SubmitButton>
     </Form>

--- a/src/components/domain/Form/Login/index.js
+++ b/src/components/domain/Form/Login/index.js
@@ -23,7 +23,7 @@ const Login = () => {
   return (
     <Form onSubmit={handleSubmit}>
       <Input
-        type="text"
+        type="email"
         name="email"
         placeholder="이메일을 입력해주세요"
         onChange={handleChange}

--- a/src/components/domain/Form/SignUp/index.js
+++ b/src/components/domain/Form/SignUp/index.js
@@ -32,7 +32,7 @@ const SignUp = () => {
   return (
     <Form onSubmit={handleSubmit}>
       <Input
-        type="text"
+        type="email"
         name="email"
         placeholder="이메일을 입력해주세요"
         onChange={handleChange}

--- a/src/components/domain/Form/SignUp/index.js
+++ b/src/components/domain/Form/SignUp/index.js
@@ -1,44 +1,68 @@
 import SubmitButton from '../SubmitButton'
+import ErrorText from '../ErrorText'
 import Form from '../index'
 import { Input } from '@components'
-import { useForm } from '@hooks'
 import { signUp } from '@apis'
+import { validateSignUp } from '@utils/validation/signUp'
+import { useFormik } from 'formik'
 
 const SignUp = () => {
-  const { handleChange, handleSubmit } = useForm({
+  const { values, errors, handleSubmit, handleChange } = useFormik({
     initialValues: {
       email: '',
       fullName: '',
       password: '',
+      passwordConfirm: '',
     },
-    onSubmit: async (userInfo) => {
-      await signUp(userInfo).then((res) => {
-        console.log(res)
-      })
+    onSubmit: async ({ email, fullName, password }) => {
+      const userInfo = {
+        email,
+        fullName,
+        password,
+      }
+      const { user, token } = await signUp(userInfo)
+      // TODO
+      // 바로 Login 적용하여 토큰 localStorage에 적용시키고
+      // userContext에 연결
+      // 회원가입 성공 시 로그인 후 main 이동
     },
+    validate: validateSignUp,
   })
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Input type="text" name="email" placeholder="이메일을 입력해주세요" onChange={handleChange} />
+      <Input
+        type="text"
+        name="email"
+        placeholder="이메일을 입력해주세요"
+        onChange={handleChange}
+        value={values.email}
+      />
+      {errors.email && <ErrorText> {errors.email}</ErrorText>}
       <Input
         type="text"
         name="fullName"
         placeholder="닉네임을 입력해주세요"
         onChange={handleChange}
+        value={values.fullName}
       />
+      {errors.fullName && <ErrorText> {errors.fullName}</ErrorText>}
       <Input
         type="password"
         name="password"
         placeholder="비밀번호를 입력해주세요"
         onChange={handleChange}
+        value={values.password}
       />
+      {errors.password && <ErrorText> {errors.password}</ErrorText>}
       <Input
         type="password"
         name="passwordConfirm"
         placeholder="비밀번호를 다시 입력해주세요"
         onChange={handleChange}
+        value={values.passwordConfirm}
       />
+      {errors.passwordConfirm && <ErrorText> {errors.passwordConfirm}</ErrorText>}
       <SubmitButton>회원가입</SubmitButton>
     </Form>
   )

--- a/src/stories/components/Input.stories.js
+++ b/src/stories/components/Input.stories.js
@@ -12,6 +12,7 @@ export default {
       defaultValue: '',
       control: 'text',
     },
+    onChange: { action: 'typing' },
     block: {
       defaultValue: false,
       control: 'boolean',

--- a/src/utils/validation/signUp.js
+++ b/src/utils/validation/signUp.js
@@ -1,0 +1,23 @@
+const validateSignUp = ({ email, fullName, password, passwordConfirm }) => {
+  const errors = {}
+
+  if (email && !/^[A-Z0-9._%+-]+@[A-Z0-s9.-]+\.[A-Z]{2,4}$/i.test(email)) {
+    errors.email = '이메일 형식이 아닙니다.'
+  }
+
+  if ((fullName && fullName.length < 2) || fullName.length > 15) {
+    errors.fullName = '닉네임을 입력해주세요(2~15자)'
+  }
+
+  if ((password && password.length < 8) || password.length > 15) {
+    errors.fullName = '비밀번호를 입력해 주세요(8~15자)'
+  }
+
+  if (passwordConfirm && password !== passwordConfirm) {
+    errors.passwordConfirm = '비밀번호가 일치하지 않습니다'
+  }
+
+  return errors
+}
+
+export { validateSignUp }

--- a/src/utils/validation/signUp.js
+++ b/src/utils/validation/signUp.js
@@ -10,7 +10,7 @@ const validateSignUp = ({ email, fullName, password, passwordConfirm }) => {
   }
 
   if ((password && password.length < 8) || password.length > 15) {
-    errors.fullName = '비밀번호를 입력해 주세요(8~15자)'
+    errors.password = '비밀번호를 입력해 주세요(8~15자)'
   }
 
   if (passwordConfirm && password !== passwordConfirm) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6177,6 +6177,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -7561,6 +7566,19 @@ format@^0.2.0:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
+formik@^2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
+  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -8170,7 +8188,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9912,6 +9930,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -12383,6 +12406,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -14159,6 +14187,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -14323,7 +14356,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
### ✅ 이슈 번호
#60, #62

### 작업 내용
1. formik 적용을 위한 input 컴포넌트 리팩토링(c2f9650a877da3ca3a5900341318370d739825aa)

type, name, value, onChange props를 추가하였습니다.

2. 로그인/회원가입 formik 적용

#### 회원가입

![회원가입](https://user-images.githubusercontent.com/50071076/173894718-dd39cc2f-aef6-4ff2-8429-4eda85727a5e.gif)
위와 같이 ErrorText 컴포넌트를 구현하여 적용하였습니다. 로그인은 ErrorText가 따로 필요하지 않을 것 같아서 구현하지 않았습니다.

또한 validation 부분을 적용시켰습니다. (utils/validation/signUp.js)
- email : email 형식 확인
- fullName: 닉네임 2~15자
- password: 비밀번호 8~15자

#### 로그인
로그인은 formik만 적용하였습니다.

`yarn start`로 3000포트에서 확인할 수 있습니다.

### 구현 날짜
2022년 6월 16일
