### PR TITLE
feat: 메인페이지에서 Post를 클릭했을 때 Post 모달을 띄우는 로직 구현

### DIFF
--- a/src/components/base/Avatar/index.js
+++ b/src/components/base/Avatar/index.js
@@ -3,6 +3,10 @@ import { useEffect, useState } from 'react'
 import ImageComponent from '../Image'
 import PropTypes from 'prop-types'
 
+// TODO
+// 여기에는 Avatar 디폴트 이미지가 들어가야 합니다. 임시로 url을 넣어놓았습니다.
+const DEFAULT_AVATAR_IMG_URL = 'https://pic.onlinewebfonts.com/svg/img_312847.png'
+
 const ShapeToCssValue = {
   circle: '50%',
   round: '40px',
@@ -24,7 +28,7 @@ const AvatarWrapper = styled.div`
 const Avatar = ({
   lazy,
   threshold,
-  src,
+  src = DEFAULT_AVATAR_IMG_URL,
   size = 70,
   shape = 'circle',
   placeholder,
@@ -62,7 +66,7 @@ Avatar.propTypes = {
   lazy: PropTypes.bool,
   threshold: PropTypes.number,
   placeholder: PropTypes.string,
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
   size: PropTypes.number,
   shape: PropTypes.oneOf(['circle', 'round', 'square']),
   alt: PropTypes.string,

--- a/src/components/domain/Post/PostContents.js
+++ b/src/components/domain/Post/PostContents.js
@@ -1,23 +1,34 @@
+import { Fragment } from 'react'
 import { Text, Title, Image } from '@components'
 
-const DEFAULT_IMAGE_URL = 'https://source.unsplash.com/random'
-
-// TODO
-// '내용'에 title을 파싱해서 넣어야 한다.
+const defaultTitleProps = {
+  bookTitle: '',
+  postContent: '',
+  postQuote: '',
+}
 
 const PostContents = ({ title, image }) => {
+  // TODO
+  // title 파싱 로직이 완성되면 이 if문은 삭제해주세요.
+  if (typeof title === 'string') {
+    title = {
+      bookTitle: '타이틀',
+      postContent: '파싱이',
+      postQuote: '완료되지 않음',
+    }
+  }
+
+  const { bookTitle, postContent, postQuote } = { ...defaultTitleProps, ...title }
+
   return (
-    <>
-      <Title style={{ margin: '0 auto', textAlign: 'center' }}>{title}</Title>
-      <Image
-        block
-        src={image || DEFAULT_IMAGE_URL}
-        width="200px"
-        height="300px"
-        style={{ margin: '0 auto' }}
-      />
-      <Text>내용</Text>
-    </>
+    <Fragment>
+      <Title style={{ margin: '0 auto', textAlign: 'center' }}>{postQuote}</Title>
+      <Image block src={image} width="200px" height="300px" style={{ margin: '0 auto' }} />
+      <Title level={3} style={{ margin: '0 auto', textAlign: 'center' }}>
+        {bookTitle}
+      </Title>
+      <Text>{postContent}</Text>
+    </Fragment>
   )
 }
 export default PostContents

--- a/src/components/domain/Post/PostContents.js
+++ b/src/components/domain/Post/PostContents.js
@@ -8,16 +8,6 @@ const defaultTitleProps = {
 }
 
 const PostContents = ({ title, image }) => {
-  // TODO
-  // title 파싱 로직이 완성되면 이 if문은 삭제해주세요.
-  if (typeof title === 'string') {
-    title = {
-      bookTitle: '타이틀',
-      postContent: '파싱이',
-      postQuote: '완료되지 않음',
-    }
-  }
-
   const { bookTitle, postContent, postQuote } = { ...defaultTitleProps, ...title }
 
   return (

--- a/src/components/domain/Post/PostHeader.js
+++ b/src/components/domain/Post/PostHeader.js
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import styled from '@emotion/styled'
 import { Text, Button } from '@components'
 import { formatTime } from './index'
@@ -14,7 +15,7 @@ const PostHeader = ({ author, createdAt }) => {
   const { image, fullName } = author
 
   return (
-    <>
+    <Fragment>
       <UserBox image={image}>
         <Text block>{fullName}</Text>
         <Text block>{formatTime(createdAt)}</Text>
@@ -23,7 +24,7 @@ const PostHeader = ({ author, createdAt }) => {
         <Button>수정</Button>
         <Button>삭제</Button>
       </AuthorizedButtons>
-    </>
+    </Fragment>
   )
 }
 

--- a/src/components/domain/Post/UserBox.js
+++ b/src/components/domain/Post/UserBox.js
@@ -1,7 +1,5 @@
 import { Avatar } from '@components'
 
-const DEFAULT_IMAGE_URL = 'https://source.unsplash.com/random'
-
 const tagMap = {
   li: 'li',
   div: 'div',
@@ -17,7 +15,7 @@ const UserBox = ({ children, image, tag = 'div', avatarSize, ...props }) => {
 
   return (
     <Tag style={{ ...defaultStyle, ...props.style }} {...props}>
-      <Avatar size={avatarSize} src={image || DEFAULT_IMAGE_URL} />
+      <Avatar size={avatarSize} src={image} />
       <div>{children}</div>
     </Tag>
   )

--- a/src/components/domain/Post/index.js
+++ b/src/components/domain/Post/index.js
@@ -5,6 +5,9 @@ import CommentList from './CommentList'
 import PostContents from './PostContents'
 import PostHeader from './PostHeader'
 
+//TODO 상수로 옮겨야 한다.
+const PLACEHOLDER_IMAGE_SRC = 'https://via.placeholder.com/200?text=LUVOOK'
+
 // TODO
 // utils로 옮겨야 할 것 같다.
 export const formatTime = (unFormattedTime) => {
@@ -22,10 +25,35 @@ const PostContainer = styled.article`
   overflow: auto;
 `
 
-const Post = ({ post, ...props }) => {
-  if (!post) return
+const defaultPostProps = {
+  likes: [],
+  comments: [],
+  _id: 'default',
+  image: PLACEHOLDER_IMAGE_SRC,
+  title: {
+    bookTitle: '',
+    postContent: '',
+    postQuote: '',
+  },
+  channel: '',
+  author: {
+    image: '',
+    fullName: '',
+  },
+  createdAt: '',
+}
 
-  const { likes, comments, _id: postId, image, title, channel, author, createdAt } = post
+const Post = ({ post, ...props }) => {
+  const {
+    likes,
+    comments,
+    _id: postId,
+    image,
+    title,
+    channel,
+    author,
+    createdAt,
+  } = { ...defaultPostProps, ...post }
 
   return (
     <PostContainer>

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Header, Banner, BookListSlider, Input, Button, Select } from '@components'
+import { Header, Banner, BookListSlider, Input, Button, Select, Modal, Post } from '@components'
 import { useState, useEffect } from 'react'
 import { getChannelList, getPostListInChannel, getChannelInfo, getSearchedBookList } from '@apis'
 
@@ -15,6 +15,12 @@ const MainPage = () => {
   const [postList, setPostList] = useState([])
   const [categoryName, setCategoryName] = useState(ALL_CATEGORY)
   const [searchedKeyword, setSearchedKeyword] = useState('')
+  const [showPostModal, setShowPostModal] = useState(false)
+  const [post, setPost] = useState(null)
+
+  const closePostModal = () => {
+    setShowPostModal(false)
+  }
 
   const getAllPost = async () => {
     const channelList = await getChannelList()
@@ -36,9 +42,9 @@ const MainPage = () => {
     setPostList(channelPostList)
   }
 
-  // TODO: 상세 포스트 모달 띄우는 로직
   const handleClickPost = (post) => {
-    console.log(post)
+    setPost(post)
+    setShowPostModal(true)
   }
 
   useEffect(() => {
@@ -97,6 +103,10 @@ const MainPage = () => {
         grid={{ fill: 'row', rows: 2 }}
         handleClick={handleClickPost}
       />
+
+      <Modal visible={showPostModal} onClose={closePostModal}>
+        <Post post={post} />
+      </Modal>
     </div>
   )
 }

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -20,6 +20,7 @@ const MainPage = () => {
 
   const closePostModal = () => {
     setShowPostModal(false)
+    setPost(null)
   }
 
   const getAllPost = async () => {


### PR DESCRIPTION
### ✅ 이슈 번호

#63 

### 작업 내용(자세히)

![PostModal](https://user-images.githubusercontent.com/64957267/174033178-bd98084a-3cf4-4516-8ec5-e4ff43215aef.gif)

[98e128e](https://github.com/prgrms-fe-devcourse/FEDC2_LUVOOK_Jieun/pull/69/commits/98e128ef12460245b1968808e459206cddceead5)
- Avatar 컴포넌트에 디폴트 이미지를 추가하고 src의 `isRequired`는 삭제하였습니다. (유저 이미지가 없을 수도 있다는 것을 고려하고 없다면 디폴트 이미지를 넣는 것이 더 좋을 것 같다고 생각됩니다.)

[4197b12](https://github.com/prgrms-fe-devcourse/FEDC2_LUVOOK_Jieun/pull/69/commits/4197b123f359e768a7948f9db69580a919d8d90b)
- 일종의 방어코드로 Post에 `defaultPostProps` 객체를 추가하였습니다.
- 일종의 방어코드로 PostContents.js에 `defaultTitleProps` 객체를 추가하였습니다.
- 아직 Title 파싱 로직이 구현이 안되어있는 상태로 PostContents.js에 `TODO`를 추가하였는데 추 후 로직이 머지되면 이 부분은 삭제하겠습니다. 첨부된 gif 미리보기에는 이 부분이 반영되어있습니다.

### 구현 날짜

2022년 6월 16일

### 어려웠던 점

List의 정보만 받아서 그대로 띄우면 됐기 때문에 그리 어렵지는 않았습니다!