### PR TITLE
fix: 좋아요가 렌더링 되지 않는 버그 수정

### DIFF
--- a/src/components/domain/Post/index.js
+++ b/src/components/domain/Post/index.js
@@ -48,6 +48,7 @@ const defaultPostProps = {
 
 const Post = ({ post, onClose, handleRerenderPost, setPost, ...props }) => {
   const [isLikeActive, setIsLikeActive] = useState(false)
+  const [likeList, setLikeList] = useState([])
   const [isCommentActive, setIsCommentActive] = useState(false)
   const [currentUserLikeInfo, setCurrentUserLikeInfo] = useState({})
   const { currentUserState } = useUserContext()
@@ -56,6 +57,7 @@ const Post = ({ post, onClose, handleRerenderPost, setPost, ...props }) => {
   const getCurrentUserLikePost = useCallback(() => {
     if (!post) return []
 
+    setLikeList(post.likes)
     const postLikeUsers = post.likes.map((like) => {
       return { userId: like.user, likeId: like._id }
     })
@@ -97,12 +99,22 @@ const Post = ({ post, onClose, handleRerenderPost, setPost, ...props }) => {
     const data = await createLikeInPost({ postId: postId })
     setIsLikeActive(true)
     setCurrentUserLikeInfo({ userId: data.user, likeId: data._id })
+    setPost({
+      ...post,
+      likes: [...likeList, data],
+    })
   }
 
   const onPostLikeDelete = async ({ userId, likeId }) => {
-    await deleteLikeInPost(likeId)
+    const deletedLike = await deleteLikeInPost(likeId)
     setIsLikeActive(false)
     setCurrentUserLikeInfo({})
+
+    const deletedLikeList = likeList.filter((like) => like._id !== deletedLike._id)
+    setPost({
+      ...post,
+      likes: deletedLikeList,
+    })
   }
 
   const handleLiked = () => {


### PR DESCRIPTION
### ✅ 이슈 번호
#124

### 작업 내용
좋아요를 불러오는 post의 데이터에 접근해서 추가/삭제할 때마다 post의 데이터를 수정함으로써 데이터를 변환하였습니다.

### 구현 날짜
2022년 6월 21일

### 어려웠던 점
없었습니다.