### PR TITLE
feat: Post 컴포넌트에서 유저이름에도 Link 추가

### DIFF
--- a/src/components/domain/Post/CommentList.js
+++ b/src/components/domain/Post/CommentList.js
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useState } from 'react'
 import { createCommentInPost, deleteCommentInPost } from '@apis/api/post'
 import { Input, Button, Text, Title, Icon } from '@components'
 import { useUserContext } from '@contexts/UserContext'
 import { formatTime } from '@utils/format'
 import UserBox from './UserBox'
+import UserLink from './UserLink'
 
 const CommentsContainer = styled.ul`
   margin: 0;
@@ -118,7 +119,8 @@ const CommentList = ({ post, comments, active, setPost }) => {
             <List key={_id}>
               <UserBox avatarSize={40} userId={userId}>
                 <Text block style={{ marginBottom: '4px' }}>
-                  {fullName} <Text size="small">{formatTime(createdAt)}</Text>
+                  <UserLink userId={userId} username={fullName} />{' '}
+                  <Text size="small">{formatTime(createdAt)}</Text>
                   {active && currentUserState.currentUser._id === author._id && (
                     <Text style={DeleteTextStyle} onClick={() => deleteComment(_id)}>
                       삭제

--- a/src/components/domain/Post/PostHeader.js
+++ b/src/components/domain/Post/PostHeader.js
@@ -6,6 +6,7 @@ import UserBox from './UserBox'
 import { useUserContext } from '@contexts/UserContext'
 import { getItem } from '@utils/storage'
 import { deletePost } from '@apis'
+import UserLink from './UserLink'
 
 const AuthorizedButtons = styled.div`
   margin: 8px 0;
@@ -67,7 +68,7 @@ const PostHeader = ({ postId, author, createdAt, onClose }) => {
     <Fragment>
       <UserBox userId={userId}>
         <Text block style={{ marginBottom: '4px' }}>
-          {fullName}
+          <UserLink userId={userId} username={fullName} />
         </Text>
         <Text size="small" block>
           {formatTime(createdAt)}

--- a/src/components/domain/Post/UserLink.js
+++ b/src/components/domain/Post/UserLink.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import { Link as ReactRouterLink } from 'react-router-dom'
+
+const Link = styled(ReactRouterLink)`
+  text-decoration: none;
+  color: inherit;
+  &:hover {
+    font-weight: 600;
+  }
+`
+
+const UserLink = ({ userId, username }) => {
+  return <Link to={`/users/${userId}`}>{username}</Link>
+}
+
+UserLink.propTypes = {
+  userId: PropTypes.string.isRequired,
+  username: PropTypes.string.isRequired,
+}
+
+export default UserLink


### PR DESCRIPTION
### ✅ 이슈 번호

#132 

### 작업 내용(자세히)

(사진 생략)

`UserLink` 컴포넌트를 생성하여 '유저이름'을 클릭했을 때 사용자 페이지로 이동하도록 하였습니다. 
hover에 `font-weight: 600` 을 주어서 사용자 경험을 조금 향상시켰습니다.

### 구현 날짜

2022년 6월 21일