### PR TITLE
feat: User의 프로필 사진이 렌더링되는 기능 추가

### DIFF
--- a/src/components/domain/Header/User/index.js
+++ b/src/components/domain/Header/User/index.js
@@ -65,7 +65,12 @@ const User = () => {
 
   return isLogin ? (
     <div>
-      <Avatar size={40} id="user" onClick={() => setUserPop(true)} />
+      <Avatar
+        size={40}
+        id="user"
+        onClick={() => setUserPop(true)}
+        src={currentUserState.currentUser.image}
+      />
       <Popover show={userPop} targetId="user" onClose={() => setUserPop(false)}>
         <UserElement>
           <li onClick={navigateMyPage}>마이 페이지</li>

--- a/src/components/domain/Header/UserSearch/index.js
+++ b/src/components/domain/Header/UserSearch/index.js
@@ -103,6 +103,7 @@ const UserSearch = ({ showModal, onClose, closeOnClick }) => {
         return {
           id: user._id,
           fullName: JSON.parse(user.fullName).fullName,
+          image: user.image,
         }
       })
     } catch (e) {
@@ -132,7 +133,7 @@ const UserSearch = ({ showModal, onClose, closeOnClick }) => {
             <Fragment key={user.id}>
               <UserSearchResult onClick={() => onClickModalWrapper}>
                 <Link to={`/users/${user.id}`} className="another-user">
-                  <Avatar src={ProfileImage} size={36} className="user-avatar" />
+                  <Avatar src={user.image || ProfileImage} size={36} className="user-avatar" />
                   <p className="user-name">{user.fullName}</p>
                 </Link>
               </UserSearchResult>

--- a/src/components/domain/Post/CommentList.js
+++ b/src/components/domain/Post/CommentList.js
@@ -110,14 +110,14 @@ const CommentList = ({ post, comments, active, setPost }) => {
 
       <CommentsContainer>
         {commentList?.map(({ _id, comment, author, createdAt }) => {
-          const { fullName: unParsedFullName, _id: userId } = author
+          const { fullName: unParsedFullName, _id: userId, image: userProfile } = author
           const { fullName } = {
             fullName: unParsedFullName,
             ...JSON.parse(unParsedFullName),
           }
           return (
             <List key={_id}>
-              <UserBox avatarSize={40} userId={userId}>
+              <UserBox avatarSize={40} userId={userId} image={userProfile}>
                 <Text block style={{ marginBottom: '4px' }}>
                   <UserLink userId={userId} username={fullName} />{' '}
                   <Text size="small">{formatTime(createdAt)}</Text>

--- a/src/components/domain/Post/PostHeader.js
+++ b/src/components/domain/Post/PostHeader.js
@@ -61,12 +61,12 @@ const PostHeader = ({ postId, author, createdAt, onClose }) => {
     }
   }
 
-  const { fullName: unParsedFullName, _id: userId } = author
+  const { fullName: unParsedFullName, _id: userId, image: userImage } = author
   const { fullName } = { fullName: unParsedFullName, ...JSON.parse(unParsedFullName) }
 
   return (
     <Fragment>
-      <UserBox userId={userId}>
+      <UserBox userId={userId} image={userImage}>
         <Text block style={{ marginBottom: '4px' }}>
           <UserLink userId={userId} username={fullName} />
         </Text>

--- a/src/components/domain/UserEditForm/index.js
+++ b/src/components/domain/UserEditForm/index.js
@@ -130,7 +130,7 @@ const UserEditForm = () => {
         {isEdit ? (
           <UserInfoContainer>
             <ProfileEdit>
-              <Avatar size={196} />
+              <Avatar size={196} src={currentUserState.currentUser.image} />
               <input
                 type="text"
                 name="fullName"
@@ -153,7 +153,7 @@ const UserEditForm = () => {
         ) : (
           <UserInfoContainer>
             <Profile>
-              <Avatar size={196} />
+              <Avatar size={196} src={currentUserState.currentUser.image} />
               <p className="user-name">{fullName}</p>
             </Profile>
             <UserContent>{quote}</UserContent>

--- a/src/components/domain/UserInfo/index.js
+++ b/src/components/domain/UserInfo/index.js
@@ -67,7 +67,7 @@ const UserInfo = ({ userInfo }) => {
   return (
     <UserInfoContainer>
       <Profile>
-        <Avatar size={196} mode="fill" />
+        <Avatar size={196} mode="fill" src={userInfo?.image} />
         <p className="user-name">{fullName.fullName}</p>
       </Profile>
       <UserContent>{fullName.quote}</UserContent>


### PR DESCRIPTION
### ✅ 이슈 번호

#138 

### 작업 내용(자세히)
![image](https://user-images.githubusercontent.com/74234333/174857015-f891cd71-34ab-40cc-bfc9-b0ccf6901845.png)
![image](https://user-images.githubusercontent.com/74234333/174857123-1ad3076b-8149-4ee9-a0f9-6ab6f9ab980c.png)
![image](https://user-images.githubusercontent.com/74234333/174857208-c33b44b9-6144-4571-add0-d5135dbefe97.png)
![image](https://user-images.githubusercontent.com/74234333/174857281-5568ed45-1d17-4ad7-8b4d-01b3418471b8.png)
![image](https://user-images.githubusercontent.com/74234333/174857337-93456003-a918-4222-abcc-126eacad91c2.png)

프로필 사진이 존재하면, 프로필 사진을 렌더링 하는 기능을 추가하였습니다

**프사 올리는 법**
썬더클라이언트에서 로그인 후,
https://kdt.frontend.2nd.programmers.co.kr:5010/users/upload-photo 의 post 메소드에 다음과 같이 요청을 하면 프사가 올라갑니다. **주의: 파일의 경우, 한글이 들어가면 안됩니다.**
![image](https://user-images.githubusercontent.com/74234333/174857468-f894f246-ecc0-4fa4-ac62-186127e8d97c.png)

### 구현 날짜

2022년 6월 22일

### 어려웠던 점
